### PR TITLE
[fix] デプロイ時に必要となる環境変数指定を追加

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -11,6 +11,8 @@ var CorsAllowOrigin = "http://localhost:3000"
 var DBHostName = "db"
 var DBPort = 3306
 var DBName = "training"
+var DBUsername = "root"
+var DBPassword = ""
 
 func init() {
 	if v := os.Getenv("HOSTNAME"); v != "" {
@@ -30,5 +32,11 @@ func init() {
 	}
 	if v := os.Getenv("DB_NAME"); v != "" {
 		DBName = v
+	}
+	if v := os.Getenv("DB_USERNAME"); v != "" {
+		DBUsername = v
+	}
+	if v := os.Getenv("DB_PASSWORD"); v != "" {
+		DBPassword = v
 	}
 }

--- a/backend/internal/external/mysql.go
+++ b/backend/internal/external/mysql.go
@@ -2,10 +2,11 @@ package external
 
 import (
 	"fmt"
-	"gorm.io/driver/mysql"
-	"gorm.io/gorm"
 	"myapp/internal/config"
 	"os"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
 )
 
 var DB *gorm.DB
@@ -16,7 +17,9 @@ func SetupDB() {
 	host := config.DBHostName
 	port := config.DBPort
 	dbname := config.DBName
-	dsn := fmt.Sprintf("root@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local", host, port, dbname)
+	dbUsername := config.DBUsername
+	dbPassword := config.DBPassword
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local", dbUsername, dbPassword, host, port, dbname)
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
デプロイ時には接続するDBユーザ名およびパスワードがローカルと異なる
それに対応するために、環境変数としてそれらを読み込み、接続時に用いる
なお、デプロイ時環境変数はECSの「タスク定義」に環境変数として定義される