### PR TITLE
投稿編集画面、削除の実装

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import {Route, Routes} from 'react-router-dom';
 import PostList from '../features/home/PostList';
 import NewPost from '../features/newPost/NewPost';
 import JoinClub from '../features/joinClub/JoinClub';
 import SignIn from '../features/signIn/SignIn';
 import PostDetail from '../features/postDetail/PostDetail';
+import EditPost from '../features/editPost/EditPost';
 
 const AppRouter: React.FC = () => {
     return (
@@ -14,6 +15,7 @@ const AppRouter: React.FC = () => {
             <Route path="/join-club" element={<JoinClub />} />
             <Route path="/signin" element={<SignIn />} />
             <Route path="/posts/:postId" element={<PostDetail />} />
+            <Route path="/posts/:postId/edit" element={<EditPost/>}/>
         </Routes>
     );
 };

--- a/frontend/src/features/editPost/EditPost.tsx
+++ b/frontend/src/features/editPost/EditPost.tsx
@@ -51,7 +51,9 @@ const EditPost: React.FC = () => {
         try {
             await updatePost(parseInt(postId!, 10), data);
             setMessage('投稿が更新されました。');
-            navigate(`/posts/${postId}`);
+            setTimeout(() => {
+                navigate(`/posts/${postId}`);
+            }, 1000);
         } catch (err) {
             if (err instanceof Error) {
                 setError(err.message);

--- a/frontend/src/features/editPost/EditPost.tsx
+++ b/frontend/src/features/editPost/EditPost.tsx
@@ -1,0 +1,114 @@
+import React, {useEffect, useState} from 'react';
+import {useNavigate, useParams} from 'react-router-dom';
+import {SubmitHandler, useForm} from 'react-hook-form';
+import {fetchPosts, updatePost} from '../../shared/services/mockApiService'; // モックAPIサービスをインポート
+import {useAuth} from '../../shared/components/AuthContext';
+
+interface IFormInput {
+    title: string;
+    content: string;
+}
+
+const EditPost: React.FC = () => {
+    const {postId} = useParams<{ postId: string }>();
+    const {userName} = useAuth();
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [message, setMessage] = useState<string | null>(null);
+    const {register, handleSubmit, setValue, formState: {errors}} = useForm<IFormInput>();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const getPost = async () => {
+            try {
+                const posts = await fetchPosts();
+                const post = posts.find(post => post.id === parseInt(postId!, 10));
+                if (!post) {
+                    setError('Post not found');
+                    return;
+                }
+                if (post.username !== userName) {
+                    navigate('/');
+                    return;
+                }
+                setValue('title', post.title);
+                setValue('content', post.content);
+            } catch (err) {
+                if (err instanceof Error) {
+                    setError(err.message);
+                } else {
+                    setError('An unexpected error occurred');
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        getPost();
+    }, [postId, userName, navigate, setValue]);
+
+    const onSubmit: SubmitHandler<IFormInput> = async (data) => {
+        try {
+            await updatePost(parseInt(postId!, 10), data);
+            setMessage('投稿が更新されました。');
+            navigate(`/posts/${postId}`);
+        } catch (err) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('An unexpected error occurred');
+            }
+        }
+    };
+
+    const handleCancel = () => {
+        navigate(`/posts/${postId}`);
+    };
+
+    if (loading) {
+        return <div className="flex justify-center items-center h-full"><span
+            className="text-lg font-semibold">Loading...</span></div>;
+    }
+
+    if (error) {
+        return <div className="flex justify-center items-center h-full"><span
+            className="text-lg font-semibold text-red-500">Error: {error}</span></div>;
+    }
+
+    return (
+        <div className="p-6 bg-white shadow-lg rounded-lg">
+            <h2 className="text-2xl font-bold text-gray-800 mb-2">投稿の編集</h2>
+            <form onSubmit={handleSubmit(onSubmit)}>
+                <div className="mb-4">
+                    <label className="block text-gray-600 mb-2">タイトル</label>
+                    <input
+                        type="text"
+                        className={`w-full p-2 border ${errors.title ? 'border-red-500' : 'border-gray-300'} rounded-md`}
+                        {...register('title', {required: 'タイトルは必須です。'})}
+                    />
+                    {errors.title && <div className="text-red-500 mt-2">{errors.title.message}</div>}
+                </div>
+                <div className="mb-4">
+                    <label className="block text-gray-600 mb-2">内容</label>
+                    <textarea
+                        className={`w-full p-2 border ${errors.content ? 'border-red-500' : 'border-gray-300'} rounded-md`}
+                        {...register('content', {required: '内容は必須です。'})}
+                    />
+                    {errors.content && <div className="text-red-500 mt-2">{errors.content.message}</div>}
+                </div>
+                <div className="flex justify-between">
+                    <button type="button" onClick={handleCancel}
+                            className="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600">キャンセル
+                    </button>
+                    <button type="submit"
+                            className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600">変更を保存する
+                    </button>
+                </div>
+                {message && <div className="text-green-500 mt-4">{message}</div>}
+                {error && <div className="text-red-500 mt-4">{error}</div>}
+            </form>
+        </div>
+    );
+};
+
+export default EditPost;

--- a/frontend/src/features/postDetail/PostDetail.tsx
+++ b/frontend/src/features/postDetail/PostDetail.tsx
@@ -61,7 +61,9 @@ const PostDetail: React.FC = () => {
             try {
                 await deletePost(post.id);
                 setMessage('投稿が削除されました');
-                navigate('/');
+                setTimeout(() => {
+                    navigate('/');
+                }, 1000);
             } catch (err) {
                 if (err instanceof Error) {
                     setError(err.message);

--- a/frontend/src/features/postDetail/PostDetail.tsx
+++ b/frontend/src/features/postDetail/PostDetail.tsx
@@ -1,13 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import { Post } from '../../shared/models/Post';
-import { useParams, Link } from 'react-router-dom';
-import { fetchPosts } from '../../shared/services/mockApiService'; // モックAPIサービスをインポート
+import React, {useEffect, useState} from 'react';
+import {Post} from '../../shared/models/Post';
+import {Link, useNavigate, useParams} from 'react-router-dom';
+import {deletePost, fetchPosts} from '../../shared/services/mockApiService'; // モックAPIサービスをインポート
+import {useAuth} from '../../shared/components/AuthContext';
 
 const PostDetail: React.FC = () => {
     const [posts, setPosts] = useState<Post[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    const { postId } = useParams<{ postId: string }>();
+    const [message, setMessage] = useState<string | null>(null);
+    const {postId} = useParams<{ postId: string }>();
+    const navigate = useNavigate();
+    const {userName} = useAuth();
 
     // ページが読み込まれた時に実行
     useEffect(() => {
@@ -32,30 +36,63 @@ const PostDetail: React.FC = () => {
 
     // ローディング中の場合
     if (loading) {
-        return <div className="flex justify-center items-center h-full"><span className="text-lg font-semibold">Loading...</span></div>;
+        return <div className="flex justify-center items-center h-full"><span
+            className="text-lg font-semibold">Loading...</span></div>;
     }
 
     // エラーが発生した場合
     if (error) {
-        return <div className="flex justify-center items-center h-full"><span className="text-lg font-semibold text-red-500">Error: {error}</span></div>;
+        return <div className="flex justify-center items-center h-full"><span
+            className="text-lg font-semibold text-red-500">Error: {error}</span></div>;
     }
 
     // パラメータで指定されたIDの投稿を取得
-    const post = postId? posts.find(post => post.id === parseInt(postId, 10)):undefined;
+    const post = postId ? posts.find(post => post.id === parseInt(postId, 10)) : undefined;
 
     // 投稿が見つからない場合
     if (!post) {
-        return <div className="flex justify-center items-center h-full"><span className="text-lg font-semibold text-red-500">Post not found</span></div>;
+        return <div className="flex justify-center items-center h-full"><span
+            className="text-lg font-semibold text-red-500">Post not found</span></div>;
     }
 
-    return(
+    // 投稿を削除する関数
+    const handleDelete = async () => {
+        if (confirm('この投稿を削除しますか？')) {
+            try {
+                await deletePost(post.id);
+                setMessage('投稿が削除されました');
+                navigate('/');
+            } catch (err) {
+                if (err instanceof Error) {
+                    setError(err.message);
+                } else {
+                    setError('An unexpected error occurred');
+                }
+            }
+        }
+    }
+
+    return (
         // 投稿詳細を表示
-        <div className="p-6 bg-white shadow-lg rounded-lg">
+        <div className="p-6 bg-white shadow-lg rounded-lg relative">
+            <button onClick={() => navigate("/new-post")}
+                    className="text-white bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded absolute top-0 right-0 m-4">新しい投稿を作成
+            </button>
             <h2 className="text-2xl font-bold text-gray-800 mb-2">{post.title}</h2>
             <p className="text-gray-600">ユーザー名: <span className="font-semibold">{post.username}</span></p>
             <p className="text-gray-500">更新日: {post.updatedAt}</p>
             <p className="text-gray-500 mt-4">{post.content}</p>
-            <Link to="/" className="text-blue-500 mt-4 block">Back to home</Link>
+            <Link to="/" className="text-blue-500 mt-4 block">ホームに戻る</Link>
+
+            {userName === post.username && (
+                <div className="mt-4">
+                    <Link to={`/posts/${post.id}/edit`} className="text-blue-500 mr-4">編集</Link>
+                    <button onClick={handleDelete} className="text-red-500">削除</button>
+                </div>
+            )}
+
+            {message && <div className="text-green-500 mt-4">{message}</div>}
+            {error && <div className="text-red-500 mt-4">{error}</div>}
         </div>
     );
 }

--- a/frontend/src/shared/services/mockApiService.ts
+++ b/frontend/src/shared/services/mockApiService.ts
@@ -1,15 +1,40 @@
-import { Post } from '../models/Post';
+import {Post} from '../models/Post';
+
+// モックデータ
+let posts: Post[] = [
+    {
+        id: 1,
+        title: 'バナナは持っていっていいですか？',
+        username: 'testuser',
+        createdAt: '2022/4/25 18:38:00',
+        updatedAt: '2022/4/25 18:38:00',
+        content: '２本目も持って行っていいですかね？'
+    },
+    {
+        id: 2,
+        title: 'test2',
+        username: 'hoge',
+        createdAt: '2022/4/25 18:38:00',
+        updatedAt: '2022/4/25 18:38:00',
+        content: 'これは二つ目のテストです。'
+    },
+];
 
 export const fetchPosts = async (): Promise<Post[]> => {
-    // モックデータ
-    const mockPosts: Post[] = [
-        { id: 1, title: 'バナナは持っていっていいですか？', username: 'hoge', createdAt: '2022/4/25 18:38:00', updatedAt: '2022/4/25 18:38:00', content: '２本目も持って行っていいですかね？' },
-        { id: 2, title: 'test2', username: 'hoge', createdAt: '2022/4/25 18:38:00', updatedAt: '2022/4/25 18:38:00', content: 'これは二つ目のテストです。' },
-    ];
-
     return new Promise(resolve => {
         setTimeout(() => {
-            resolve(mockPosts);
+            resolve(posts);
         }, 1000); // 1秒の遅延をシミュレート
     });
+};
+
+export const deletePost = async (postId: number): Promise<void> => {
+    posts = posts.filter(post => post.id !== postId);
+}
+
+export const updatePost = async (postId: number, data: { title: string, content: string }): Promise<void> => {
+    const postIndex = posts.findIndex(post => post.id === postId);
+    if (postIndex > -1) {
+        posts[postIndex] = {...posts[postIndex], ...data, updatedAt: new Date().toISOString()};
+    }
 };


### PR DESCRIPTION
close: #19

## 概要
投稿の詳細画面に、編集・削除・新しい投稿の作成ボタンを設置

## やったこと
- 投稿の詳細画面に以下を追加
  - 編集 (ログイン中のuserと投稿者のnameが一致した時のみ表示)
  - 削除 (ログイン中のuserと投稿者のnameが一致した時のみ表示)
  - 新規投稿ボタン
- 投稿編集画面の作成

## 見てほしいファイル
- `frontend/src/features/editPost/EditPost.tsx`
- `frontend/src/features/postDetail/PostDetail.tsx`

## スクリーンショット
![image](https://github.com/givery-bootcamp/dena-2024-team9/assets/58862935/eaa5f66f-b678-4dce-8a66-0e1a9068c929)

<img width="1863" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/58862935/3bd80ef8-2009-47d2-a6b7-10dbc752921f">
<img width="1862" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/58862935/e4e66fd1-9c43-4317-b34b-8a6c342e5e41">

