### PR TITLE
【フロント】バックエンドとの統合

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - db
     environment:
       TZ: Asia/Tokyo
+
   frontend:
     image: node:20.12.2
     working_dir: /home/node/myapp

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-VITE_API_ENDPOINT_PATH=http://localhost:9000
+VITE_API_ENDPOINT_PATH=https://team-9_bk.member0005.track-bootcamp.run

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_API_ENDPOINT_PATH=http://localhost:9000

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,3 @@
+const API_BASE_URL = import.meta.env.VITE_API_ENDPOINT_PATH as string;
+
+export default API_BASE_URL;

--- a/frontend/src/features/editPost/EditPost.tsx
+++ b/frontend/src/features/editPost/EditPost.tsx
@@ -28,7 +28,7 @@ const EditPost: React.FC = () => {
                     return;
                 }
                 setValue('title', post.title);
-                setValue('content', post.body); // 'body' から 'content' に変更
+                setValue('content', post.body);
             } catch (err) {
                 if (err instanceof Error) {
                     setError(err.message);

--- a/frontend/src/features/editPost/EditPost.tsx
+++ b/frontend/src/features/editPost/EditPost.tsx
@@ -1,13 +1,10 @@
 import React, {useEffect, useState} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
 import {SubmitHandler, useForm} from 'react-hook-form';
-import {fetchPosts, updatePost} from '../../shared/services/mockApiService'; // モックAPIサービスをインポート
+import {fetchPostById, updatePost} from '../../shared/services/apiService'; // APIサービスの関数をインポート
 import {useAuth} from '../../shared/components/AuthContext';
+import {IFormInput} from '../../shared/models/Post';
 
-interface IFormInput {
-    title: string;
-    content: string;
-}
 
 const EditPost: React.FC = () => {
     const {postId} = useParams<{ postId: string }>();
@@ -21,8 +18,7 @@ const EditPost: React.FC = () => {
     useEffect(() => {
         const getPost = async () => {
             try {
-                const posts = await fetchPosts();
-                const post = posts.find(post => post.id === parseInt(postId!, 10));
+                const post = await fetchPostById(parseInt(postId!, 10)); // 単一の投稿を取得するAPI関数を使用
                 if (!post) {
                     setError('Post not found');
                     return;
@@ -32,7 +28,7 @@ const EditPost: React.FC = () => {
                     return;
                 }
                 setValue('title', post.title);
-                setValue('content', post.content);
+                setValue('content', post.body); // 'body' から 'content' に変更
             } catch (err) {
                 if (err instanceof Error) {
                     setError(err.message);
@@ -49,7 +45,7 @@ const EditPost: React.FC = () => {
 
     const onSubmit: SubmitHandler<IFormInput> = async (data) => {
         try {
-            await updatePost(parseInt(postId!, 10), data);
+            await updatePost(postId, data);
             setMessage('投稿が更新されました。');
             setTimeout(() => {
                 navigate(`/posts/${postId}`);

--- a/frontend/src/features/home/PostList.tsx
+++ b/frontend/src/features/home/PostList.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import { Post } from '../../shared/models/Post';
-import { Link } from 'react-router-dom';
-import { fetchPosts } from '../../shared/services/mockApiService'; // モックAPIサービスをインポート
+import React, {useEffect, useState} from 'react';
+import {Post} from '../../shared/models/Post';
+import {Link} from 'react-router-dom';
+import {fetchPosts} from '../../shared/services/apiService';
 
 const PostList: React.FC = () => {
     const [posts, setPosts] = useState<Post[]>([]);
@@ -42,7 +42,7 @@ const PostList: React.FC = () => {
                 <div key={post.id} className="border-b last:border-b-0 last:mb-0 last:pb-0">
                     <h2 className="text-2xl font-bold text-gray-800 mb-2">{post.title}</h2>
                     <p className="text-gray-600">ユーザー名: <span className="font-semibold">{post.username}</span></p>
-                    <p className="text-gray-500">更新日: {post.updatedAt}</p>
+                    <p className="text-gray-500">更新日: {post.updated_at}</p>
                 </div>
                 </Link>
             ))}

--- a/frontend/src/features/postDetail/PostDetail.tsx
+++ b/frontend/src/features/postDetail/PostDetail.tsx
@@ -1,12 +1,8 @@
 import React, {useEffect, useState} from 'react';
 import {Post} from '../../shared/models/Post';
 import {Link, useNavigate, useParams} from 'react-router-dom';
-import {deletePost, fetchPosts} from '../../shared/services/mockApiService'; // モックAPIサービスをインポート
 import {useAuth} from '../../shared/components/AuthContext';
-import React, {useEffect, useState} from 'react';
-import {Post} from '../../shared/models/Post';
-import {Link, useParams} from 'react-router-dom';
-import {fetchPostById} from '../../shared/services/apiService';
+import {deletePost, fetchPostById} from '../../shared/services/apiService';
 
 const PostDetail: React.FC = () => {
     const [post, setPost] = useState<Post | null>(null);

--- a/frontend/src/features/postDetail/PostDetail.tsx
+++ b/frontend/src/features/postDetail/PostDetail.tsx
@@ -1,21 +1,22 @@
-import React, { useState, useEffect } from 'react';
-import { Post } from '../../shared/models/Post';
-import { useParams, Link } from 'react-router-dom';
-import { fetchPosts } from '../../shared/services/mockApiService'; // モックAPIサービスをインポート
+import React, {useEffect, useState} from 'react';
+import {Post} from '../../shared/models/Post';
+import {Link, useParams} from 'react-router-dom';
+import {fetchPostById} from '../../shared/services/apiService';
 
 const PostDetail: React.FC = () => {
-    const [posts, setPosts] = useState<Post[]>([]);
+    const [post, setPost] = useState<Post | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const { postId } = useParams<{ postId: string }>();
 
+
     // ページが読み込まれた時に実行
     useEffect(() => {
-        const getPosts = async () => {
+        const getPost = async () => {
             try {
-                // モックAPIサービスを呼び出し
-                const data = await fetchPosts();
-                setPosts(data);
+                const data = await fetchPostById(parseInt(postId!, 10));
+                console.log(data);
+                setPost(data);
             } catch (err) {
                 if (err instanceof Error) {
                     setError(err.message);
@@ -27,8 +28,10 @@ const PostDetail: React.FC = () => {
             }
         };
 
-        getPosts();
-    }, []);
+        if (postId) {
+            getPost();
+        }
+    }, [postId]);
 
     // ローディング中の場合
     if (loading) {
@@ -40,22 +43,20 @@ const PostDetail: React.FC = () => {
         return <div className="flex justify-center items-center h-full"><span className="text-lg font-semibold text-red-500">Error: {error}</span></div>;
     }
 
-    // パラメータで指定されたIDの投稿を取得
-    const post = postId? posts.find(post => post.id === parseInt(postId, 10)):undefined;
-
     // 投稿が見つからない場合
     if (!post) {
         return <div className="flex justify-center items-center h-full"><span className="text-lg font-semibold text-red-500">Post not found</span></div>;
     }
 
-    return(
-        // 投稿詳細を表示
+    return (
         <div className="p-6 bg-white shadow-lg rounded-lg">
             <h2 className="text-2xl font-bold text-gray-800 mb-2">{post.title}</h2>
             <p className="text-gray-600">ユーザー名: <span className="font-semibold">{post.username}</span></p>
-            <p className="text-gray-500">更新日: {post.updatedAt}</p>
-            <p className="text-gray-500 mt-4">{post.content}</p>
+            <p className="text-gray-500">更新日: {post.updated_at}</p>
+            <p className="text-gray-500 mt-4">{post.body}</p>
             <Link to="/" className="text-blue-500 mt-4 block">Back to home</Link>
+
+            {error && <div className="text-red-500 mt-4">{error}</div>}
         </div>
     );
 }

--- a/frontend/src/shared/models/Post.ts
+++ b/frontend/src/shared/models/Post.ts
@@ -1,8 +1,9 @@
 export interface Post {
     id: number;
     title: string;
+    body: string;
+    user_id: number;
     username: string;
-    createdAt: string;
-    updatedAt: string;
-    content: string;
+    created_at: string;
+    updated_at: string;
 }

--- a/frontend/src/shared/models/Post.ts
+++ b/frontend/src/shared/models/Post.ts
@@ -7,3 +7,8 @@ export interface Post {
     created_at: string;
     updated_at: string;
 }
+
+export interface IFormInput {
+    title: string;
+    content: string; // 'body' から 'content' に変更
+}

--- a/frontend/src/shared/services/apiService.ts
+++ b/frontend/src/shared/services/apiService.ts
@@ -1,5 +1,6 @@
 import {Post} from '../models/Post';
 import API_BASE_URL from '../../config';
+import {IFormInput} from '../models/Post.ts';
 
 
 export const fetchPosts = async (): Promise<Post[]> => {
@@ -39,7 +40,7 @@ export const deletePost = async (id: number): Promise<void> => {
     }
 };
 
-export const updatePost = async (id: number, data: { title: string, body: string }): Promise<void> => {
+export const updatePost = async (id: string | undefined, data: IFormInput): Promise<void> => {
     const response = await fetch(`${API_BASE_URL}/posts/${id}`, {
         method: 'PUT',
         headers: {

--- a/frontend/src/shared/services/apiService.ts
+++ b/frontend/src/shared/services/apiService.ts
@@ -1,11 +1,53 @@
-import { Post } from '../models/Post';
+import {Post} from '../models/Post';
+import API_BASE_URL from '../../config';
 
-const API_BASE_URL = 'https://api.example.com';
 
 export const fetchPosts = async (): Promise<Post[]> => {
-    const response = await fetch(`${API_BASE_URL}/posts`);
+    const response = await fetch(`${API_BASE_URL}/posts`, {
+        headers: {
+            'Content-Type': 'application/json',
+        }
+    });
+    console.log(response);
     if (!response.ok) {
         throw new Error('Failed to fetch posts');
     }
     return response.json();
+};
+
+export const fetchPostById = async (id: number): Promise<Post> => {
+    const response = await fetch(`${API_BASE_URL}/posts/${id}`, {
+        headers: {
+            'Content-Type': 'application/json',
+        }
+    });
+    if (!response.ok) {
+        throw new Error('Failed to fetch post');
+    }
+    return response.json();
+}
+
+export const deletePost = async (id: number): Promise<void> => {
+    const response = await fetch(`${API_BASE_URL}/posts/${id}`, {
+        method: 'DELETE',
+        headers: {
+            'Content-Type': 'application/json',
+        }
+    });
+    if (!response.ok) {
+        throw new Error('Failed to delete post');
+    }
+};
+
+export const updatePost = async (id: number, data: { title: string, body: string }): Promise<void> => {
+    const response = await fetch(`${API_BASE_URL}/posts/${id}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data)
+    });
+    if (!response.ok) {
+        throw new Error('Failed to update post');
+    }
 };

--- a/frontend/src/shared/services/mockApiService.ts
+++ b/frontend/src/shared/services/mockApiService.ts
@@ -6,17 +6,19 @@ let posts: Post[] = [
         id: 1,
         title: 'バナナは持っていっていいですか？',
         username: 'testuser',
-        createdAt: '2022/4/25 18:38:00',
-        updatedAt: '2022/4/25 18:38:00',
-        content: '２本目も持って行っていいですかね？'
+        created_at: '2022/4/25 18:38:00',
+        updated_at: '2022/4/25 18:38:00',
+        body: '２本目も持って行っていいですかね？',
+        user_id: 0
     },
     {
         id: 2,
         title: 'test2',
         username: 'hoge',
-        createdAt: '2022/4/25 18:38:00',
-        updatedAt: '2022/4/25 18:38:00',
-        content: 'これは二つ目のテストです。'
+        created_at: '2022/4/25 18:38:00',
+        updated_at: '2022/4/25 18:38:00',
+        body: 'これは二つ目のテストです。',
+        user_id: 0
     },
 ];
 
@@ -35,6 +37,6 @@ export const deletePost = async (postId: number): Promise<void> => {
 export const updatePost = async (postId: number, data: { title: string, content: string }): Promise<void> => {
     const postIndex = posts.findIndex(post => post.id === postId);
     if (postIndex > -1) {
-        posts[postIndex] = {...posts[postIndex], ...data, updatedAt: new Date().toISOString()};
+        posts[postIndex] = {...posts[postIndex], ...data, updated_at: new Date().toISOString()};
     }
 };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,7 +17,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
close #26 

## 概要
これまでモックAPIを叩いていた部分を本番サーバーからデータを取得する形に改良しました。

## やったこと

- apiService.tsをAPIサービスに準拠するよう修正し、本番サーバーからデータを取得
- PostList.tsxとEditPost.tsxをリファクタリング
- PostList.tsx, EditPost.tsx, PostDetail.tsxのコードをAPIサービスに準拠するよう変更

## 見てほしいファイル

- frontend/src/features/editPost/EditPost.tsx
- frontend/src/features/postDetail/PostDetail.tsx
- frontend/src/shared/models/Post.ts
- frontend/src/shared/services/apiService.ts