### PR TITLE
【バックエンド】DB設定の修正

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -8,7 +8,7 @@ import (
 var HostName = "127.0.0.1"
 var Port = 9000
 var CorsAllowOrigin = "http://localhost:3000"
-var DBHostName = "172.19.0.3"
+var DBHostName = "db"
 var DBPort = 3306
 var DBName = "training"
 var DBUsername = "user"

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -8,11 +8,11 @@ import (
 var HostName = "127.0.0.1"
 var Port = 9000
 var CorsAllowOrigin = "http://localhost:3000"
-var DBHostName = "db"
+var DBHostName = "172.19.0.3"
 var DBPort = 3306
 var DBName = "training"
-var DBUsername = "root"
-var DBPassword = ""
+var DBUsername = "user"
+var DBPassword = "password"
 
 func init() {
 	if v := os.Getenv("HOSTNAME"); v != "" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,5 +36,7 @@ services:
     ports:
       - '3306:3306'
     environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=training
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=password
+      - MYSQL_ROOT_PASSWORD=rootpassword


### PR DESCRIPTION
## 概要

バックエンドをローカルのdockerにデプロイ時に、DBに接続できない事象が発生したため、それに伴い修正。

### エラー内容
```
2024/06/18 15:05:30 /go/src/myapp/internal/external/mysql.go:25
2024-06-18T06:05:30.117178220Z [error] failed to initialize database, got error Error 1045 (28000): Access denied for user 'root'@'172.19.0.4' (using password: NO)
2024-06-18T06:05:30.117179970Z Error 1045 (28000): Access denied for user 'root'@'172.19.0.4' (using password: NO)
```

## 修正箇所
- docker-compose.yml
  - dbの設定を変更
    - MYSQL_USERとそのパスワードを設定
    - `MYSQL_ALLOW_EMPTY_PASSWORD=yes`を削除し、rootパスワードを設定