### PR TITLE
削除時のモーダルをカスタムモーダルに変更

### DIFF
--- a/frontend/src/features/postDetail/PostDetail.tsx
+++ b/frontend/src/features/postDetail/PostDetail.tsx
@@ -4,6 +4,8 @@ import {Link, useNavigate, useParams} from 'react-router-dom';
 import {useAuth} from '../../shared/components/AuthContext';
 import {deletePost, fetchPostById} from '../../shared/services/apiService';
 import {useAlert} from '../../shared/components/AlertContext';
+import ConfirmModal from '../../shared/components/Modal';
+import { useConfirmModal } from '../../shared/hooks/useConfirmModal';
 
 const PostDetail: React.FC = () => {
     const [post, setPost] = useState<Post | null>(null);
@@ -14,6 +16,8 @@ const PostDetail: React.FC = () => {
     const {userName} = useAuth();
     const {showAlert} = useAlert();
 
+    // Modalを表示するためのカスタムフック
+    const {modalRef, confirmMessage, onConfirm, onCancel, customConfirm} = useConfirmModal();
 
     // ページが読み込まれた時に実行
     useEffect(() => {
@@ -58,7 +62,9 @@ const PostDetail: React.FC = () => {
 
     // 投稿を削除する関数
     const handleDelete = async () => {
-        if (confirm('この投稿を削除しますか？')) {
+        // モーダルを表示
+        const result = await customConfirm('投稿を削除しますか？');
+        if (result) {
             try {
                 await deletePost(post.id);
                 showAlert('投稿が削除されました');
@@ -95,6 +101,7 @@ const PostDetail: React.FC = () => {
             )}
 
             {error && <div className="text-red-500 mt-4">{error}</div>}
+            <ConfirmModal message={confirmMessage} modalRef={modalRef} onConfirm={onConfirm} onCancel={onCancel}></ConfirmModal>
         </div>
     );
 }

--- a/frontend/src/shared/components/Modal.tsx
+++ b/frontend/src/shared/components/Modal.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 
-const ConfirmModal = ({ message, modalRef, onConfirm, onCancel }) => {
+interface ConfirmModalProps {
+  message: string | null;
+  modalRef: React.RefObject<HTMLDialogElement>;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+const ConfirmModal = ({ message, modalRef, onConfirm, onCancel }: ConfirmModalProps) => {
 
   return (
     <dialog className="fixed inset-0 items-center justify-center backdrop-blur-sm" ref={modalRef}>  

--- a/frontend/src/shared/components/Modal.tsx
+++ b/frontend/src/shared/components/Modal.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const ConfirmModal = ({ message, modalRef, onConfirm, onCancel }) => {
+
+  return (
+    <dialog className="fixed inset-0 items-center justify-center backdrop-blur-sm" ref={modalRef}>  
+      <div className="bg-white p-6 rounded-lg shadow-lg">
+        <p className="text-sm text-gray-700 mb-4">{message}</p>
+        <div className="flex justify-center">
+          <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 focus:outline-none mr-2" onClick={onConfirm}>はい</button>
+          <button className="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 focus:outline-none" onClick={onCancel}>いいえ</button>
+        </div>
+      </div>
+    </dialog>
+  );
+};
+
+export default ConfirmModal;

--- a/frontend/src/shared/hooks/useConfirmModal.ts
+++ b/frontend/src/shared/hooks/useConfirmModal.ts
@@ -1,0 +1,27 @@
+import { useRef, useState } from "react";
+
+export const useConfirmModal = () => {
+    const modalRef = useRef<HTMLDialogElement>(null);
+    const [confirmMessage, setConfirmMessage] = useState<string | null>(null);
+    const [resolveCallback, setResolveCallback] = useState<(value: boolean) => void | null>();
+
+    const customConfirm = async (message: string) => {
+        setConfirmMessage(message);
+        modalRef.current?.showModal();
+        return new Promise<boolean>((resolve) => {
+            setResolveCallback(() => resolve);
+        });
+    }
+
+    const onConfirm = () => {
+        if (resolveCallback) resolveCallback(true);
+        modalRef.current?.close();
+    }
+
+    const onCancel = () => {
+        if (resolveCallback) resolveCallback(false);
+        modalRef.current?.close();
+    }
+    
+    return { modalRef, confirmMessage, onConfirm, onCancel, customConfirm};
+};

--- a/frontend/src/shared/hooks/useConfirmModal.ts
+++ b/frontend/src/shared/hooks/useConfirmModal.ts
@@ -14,12 +14,12 @@ export const useConfirmModal = () => {
     }
 
     const onConfirm = () => {
-        if (resolveCallback) resolveCallback(true);
+        resolveCallback?.(true);
         modalRef.current?.close();
     }
 
     const onCancel = () => {
-        if (resolveCallback) resolveCallback(false);
+        resolveCallback?.(false);
         modalRef.current?.close();
     }
     


### PR DESCRIPTION
Close #21 

投稿削除時のモーダルをjsのconfirm()からカスタムモーダルに変更した. 

変更前. 
<img width="1247" alt="スクリーンショット 2024-06-18 17 57 37" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/48411276/1cf32de1-9e16-467e-9b56-55e926b2d389">

変更後. 
<img width="1243" alt="スクリーンショット 2024-06-18 17 56 02" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/48411276/2f3b0dda-ce8b-46c4-b06d-01f6a08efa75">
