### PR TITLE
[step2.a] サインアウトAPIの実装

### DIFF
--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -54,4 +54,5 @@ func PostSignout(ctx *gin.Context, usecase *usecases.PostSignoutUsecase) {
 	ctx.SetSameSite(http.SameSiteStrictMode)
 	// ヘッダーにトークンをセット
 	ctx.SetCookie("jwt", tokenString, -1, "/", "", false, true)
+	ctx.JSON(http.StatusOK, "signed out successfully")
 }

--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -41,3 +41,17 @@ func PostSignin(ctx *gin.Context, usecase *usecases.PostSigninUsecase) {
 	ctx.SetCookie("jwt", tokenString, 3600, "/", "", false, true)
 	ctx.JSON(http.StatusOK, user)
 }
+
+func PostSignout(ctx *gin.Context, usecase *usecases.PostSignoutUsecase) {
+
+	tokenString, err := usecase.Execute()
+	if err != nil {
+		log.Printf("Unexpected error in PostSignin: %v", err)
+		handleError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	ctx.SetSameSite(http.SameSiteStrictMode)
+	// ヘッダーにトークンをセット
+	ctx.SetCookie("jwt", tokenString, -1, "/", "", false, true)
+}

--- a/backend/internal/middleware/handler.go
+++ b/backend/internal/middleware/handler.go
@@ -34,3 +34,8 @@ func (h *Handler) PostSignin(ctx *gin.Context) {
 	usecase := usecases.NewPostSigninUsecase(h.UserRepository)
 	controllers.PostSignin(ctx, usecase)
 }
+
+func (h *Handler) PostSignout(ctx *gin.Context) {
+	usecase := usecases.NewPostSignoutUsecase(h.UserRepository)
+	controllers.PostSignout(ctx, usecase)
+}

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -20,7 +20,7 @@ func SetupRoutes(app *gin.Engine) {
 	authGroup.GET("", func(ctx *gin.Context) {
 		ctx.JSON(http.StatusOK, gin.H{"message": "you are authorized"})
 	})
-	authGroup.POST("/signout", h.PostSignout)
+	app.POST("/signout", h.PostSignout)
 
 	app.GET("/healthcheck", func(ctx *gin.Context) {
 		ctx.String(200, "It works")

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -20,6 +20,7 @@ func SetupRoutes(app *gin.Engine) {
 	authGroup.GET("", func(ctx *gin.Context) {
 		ctx.JSON(http.StatusOK, gin.H{"message": "you are authorized"})
 	})
+	authGroup.POST("/signout", h.PostSignout)
 
 	app.GET("/healthcheck", func(ctx *gin.Context) {
 		ctx.String(200, "It works")

--- a/backend/internal/usecases/user_usecase.go
+++ b/backend/internal/usecases/user_usecase.go
@@ -64,7 +64,9 @@ func NewPostSignoutUsecase(r *repositories.UserRepository) *PostSignoutUsecase {
 func (u *PostSignoutUsecase) Execute() (string, error) {
 
 	// トークンの発行（ヘッダー・ペイロード）
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{})
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iat": time.Now().Unix(),
+	})
 
 	tokenString, err := token.SignedString([]byte(SECRET_KEY))
 	if err != nil {

--- a/backend/internal/usecases/user_usecase.go
+++ b/backend/internal/usecases/user_usecase.go
@@ -50,3 +50,26 @@ func (u *PostSigninUsecase) Execute(username, password string) (*entities.User, 
 
 	return user, tokenString, nil
 }
+
+type PostSignoutUsecase struct {
+	repository entities.UserRepository
+}
+
+func NewPostSignoutUsecase(r *repositories.UserRepository) *PostSignoutUsecase {
+	return &PostSignoutUsecase{
+		repository: r,
+	}
+}
+
+func (u *PostSignoutUsecase) Execute() (string, error) {
+
+	// トークンの発行（ヘッダー・ペイロード）
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{})
+
+	tokenString, err := token.SignedString([]byte(SECRET_KEY))
+	if err != nil {
+		return tokenString, err
+	}
+
+	return tokenString, nil
+}

--- a/frontend/src/shared/components/SignInStatus.tsx
+++ b/frontend/src/shared/components/SignInStatus.tsx
@@ -1,15 +1,35 @@
 import React from 'react';
 import {useAuth} from './AuthContext.tsx';
+import API_BASE_URL from "../../config.ts";
 
 const SignInStatus: React.FC = () => {
     const {isLoggedIn, userName, signOut} = useAuth();
+
+    const handleSignOut = async () => {
+        try {
+            const response = await fetch(`${API_BASE_URL}/signout`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                credentials: 'include',
+            });
+            if (!response.ok) {
+                throw new Error('Sign out failed');
+            }
+        } catch (error) {
+            console.error(error);
+        }
+
+        signOut();
+    }
 
     return (
         <div className="flex items-center space-x-4">
             {isLoggedIn ? (
                 <>
                     <span>{userName}</span>
-                    <button onClick={signOut} className="btn">
+                    <button onClick={handleSignOut} className="btn">
                         サインアウト
                     </button>
                 </>


### PR DESCRIPTION
close #16 
サインアウトを行う処理を実装。フロント・バック両方とも実装済み
サインアウトとは、cookieに設定された`jwt`項目を削除することにあたる

フロントエンド視点では、サインイン状態で右上のサインアウトボタンを押すとサインアウトする
バックエンド視点では、`POST /signout`リクエストを受け取ったら、cookieの`jwt`項目を削除するレスポンスを返す(`Max-Age: -1`を指定した`Set-Cookie`を返す)

正常な動作

https://github.com/givery-bootcamp/dena-2024-team9/assets/61158776/3dd528e8-da04-4560-9d15-daaf16bb081d

