### PR TITLE
[step2.a] サインインユーザ取得APIの実装

### DIFF
--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -41,3 +41,30 @@ func PostSignin(ctx *gin.Context, usecase *usecases.PostSigninUsecase) {
 	ctx.SetCookie("jwt", tokenString, 3600, "/", "", false, true)
 	ctx.JSON(http.StatusOK, user)
 }
+
+func GetUser(ctx *gin.Context, usecase *usecases.GetUserUsecase) {
+
+	anyUserInfo, ok := ctx.Get("userInfo")
+	if !ok {
+		handleError(ctx, http.StatusInternalServerError, errors.New("user info not found"))
+		return
+	}
+	userInfo, ok := anyUserInfo.(map[string]interface{})
+	if !ok {
+		handleError(ctx, http.StatusInternalServerError, errors.New("user info cannot be converted"))
+		return
+	}
+	userId, ok := userInfo["Id"].(int)
+	if !ok {
+		handleError(ctx, http.StatusInternalServerError, errors.New("user id not found"))
+		return
+	}
+	user, err := usecase.Execute(userId)
+	if err != nil {
+		log.Printf("Unexpected error in GetUser: %v", err)
+		handleError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, user)
+}

--- a/backend/internal/middleware/handler.go
+++ b/backend/internal/middleware/handler.go
@@ -34,3 +34,8 @@ func (h *Handler) PostSignin(ctx *gin.Context) {
 	usecase := usecases.NewPostSigninUsecase(h.UserRepository)
 	controllers.PostSignin(ctx, usecase)
 }
+
+func (h *Handler) GetUser(ctx *gin.Context) {
+	usecase := usecases.NewGetUserUsecase(h.UserRepository)
+	controllers.GetUser(ctx, usecase)
+}

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -20,6 +20,7 @@ func SetupRoutes(app *gin.Engine) {
 	authGroup.GET("", func(ctx *gin.Context) {
 		ctx.JSON(http.StatusOK, gin.H{"message": "you are authorized"})
 	})
+	authGroup.GET("/user", h.GetUser)
 
 	app.GET("/healthcheck", func(ctx *gin.Context) {
 		ctx.String(200, "It works")

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -34,7 +34,6 @@ func (r *UserRepository) GetUserById(id int) (*entities.User, error) {
 	if err := r.Conn.Table("users").Select("id, name, password, created_at, updated_at").Where("id = ?", id).First(&user).Error; err != nil {
 		return nil, err
 	}
-	fmt.Printf("%+v\n", user)
 	return entities.NewUser(user.Id, user.Name, user.Password, user.CreatedAt, user.UpdatedAt), nil
 }
 

--- a/backend/internal/usecases/user_usecase.go
+++ b/backend/internal/usecases/user_usecase.go
@@ -50,3 +50,23 @@ func (u *PostSigninUsecase) Execute(username, password string) (*entities.User, 
 
 	return user, tokenString, nil
 }
+
+type GetUserUsecase struct {
+	repository entities.UserRepository
+}
+
+func NewGetUserUsecase(r *repositories.UserRepository) *GetUserUsecase {
+	return &GetUserUsecase{
+		repository: r,
+	}
+}
+
+func (u *GetUserUsecase) Execute(userId int) (*entities.User, error) {
+
+	// Call repository
+	user, err := u.repository.GetUserById(userId)
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
+}


### PR DESCRIPTION
close #17 
ログイン状態において、`GET /user`をリクエストすることで自身のUserインスタンスを返却するAPIを作成

jwtトークンの中にある`Id`を参照し、最新のUserインスタンスを返却する
認証されていない(適切なjwtトークンが無い)場合、401が返却される

検証項目
- 認証されていない状態(cookieにjwtが含まれなかったり、不正だった場合)に401が戻ってくること
- 認証されている状態で、200番とUser情報(DBに入ってるやつ全部)が返ってくること

検証する上で、cookieをcurlで扱うにあたり[この記事](https://qiita.com/beckyJPN/items/e85d40459e7e535dae73)が参考になる