### PR TITLE
ポスト一覧にページネーションを追加

### DIFF
--- a/frontend/src/features/home/PostList.tsx
+++ b/frontend/src/features/home/PostList.tsx
@@ -44,15 +44,20 @@ const PostList: React.FC = () => {
                       className='block border-b mb-6 last:border-b-0 last:mb-0 last:pb-0 hover:bg-gray-100 transition-colors duration-200'>
                     <div key={post.id} className="border-b last:border-b-0 last:mb-0 last:pb-0">
                         <h2 className="text-2xl font-bold text-gray-800 mb-2">{post.title}</h2>
-                        <p className="text-gray-600">ユーザー名: <span className="font-semibold">{post.username}</span>
-                        </p>
+                        <p className="text-gray-600">ユーザー名: <span className="font-semibold">{post.username}</span></p>
                         <p className="text-gray-500">更新日: {post.updated_at}</p>
                     </div>
                 </Link>
             ))}
-            <button onClick={() => setPage(prevPage => prevPage + 1)}>
-                Load more posts
-            </button>
+            <div className="mt-4 d-flex justify-content-center">
+                <button className="mx-2" onClick={() => setPage(prevPage => Math.max(prevPage - 1, 1))} disabled={page === 1}>
+                    Previous Page: {page - 1}
+                </button>
+                <span>Current Page: {page}</span>
+                <button className="mx-2" onClick={() => setPage(prevPage => prevPage + 1)}>
+                    Next Page: {page + 1}
+                </button>
+            </div>
         </div>
     );
 };

--- a/frontend/src/features/home/PostList.tsx
+++ b/frontend/src/features/home/PostList.tsx
@@ -3,29 +3,31 @@ import {Post} from '../../shared/models/Post';
 import {Link} from 'react-router-dom';
 import {fetchPosts} from '../../shared/services/apiService';
 
+
 const PostList: React.FC = () => {
     const [posts, setPosts] = useState<Post[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
+    const POSTS_PER_PAGE = 7; // 1ページでみやすい上限の数が7くらい
+    const [page, setPage] = useState<number>(1);
+
+
     useEffect(() => {
         const getPosts = async () => {
             try {
-                const data = await fetchPosts();
+                setLoading(true);
+                const data = await fetchPosts({ page, limit: POSTS_PER_PAGE });
                 setPosts(data);
             } catch (err) {
-                if (err instanceof Error) {
-                    setError(err.message);
-                } else {
-                    setError('An unexpected error occurred');
-                }
+                setError('An unexpected error occurred');
             } finally {
                 setLoading(false);
             }
         };
 
         getPosts();
-    }, []);
+    }, [page]);
 
     if (loading) {
         return <div className="flex justify-center items-center h-full"><span className="text-lg font-semibold">Loading...</span></div>;
@@ -38,14 +40,19 @@ const PostList: React.FC = () => {
     return (
         <div className="p-6 bg-white shadow-lg rounded-lg">
             {posts.map(post => (
-                <Link to={`/posts/${post.id}`} key={post.id} className='block border-b mb-6 last:border-b-0 last:mb-0 last:pb-0 hover:bg-gray-100 transition-colors duration-200'>
-                <div key={post.id} className="border-b last:border-b-0 last:mb-0 last:pb-0">
-                    <h2 className="text-2xl font-bold text-gray-800 mb-2">{post.title}</h2>
-                    <p className="text-gray-600">ユーザー名: <span className="font-semibold">{post.username}</span></p>
-                    <p className="text-gray-500">更新日: {post.updated_at}</p>
-                </div>
+                <Link to={`/posts/${post.id}`} key={post.id}
+                      className='block border-b mb-6 last:border-b-0 last:mb-0 last:pb-0 hover:bg-gray-100 transition-colors duration-200'>
+                    <div key={post.id} className="border-b last:border-b-0 last:mb-0 last:pb-0">
+                        <h2 className="text-2xl font-bold text-gray-800 mb-2">{post.title}</h2>
+                        <p className="text-gray-600">ユーザー名: <span className="font-semibold">{post.username}</span>
+                        </p>
+                        <p className="text-gray-500">更新日: {post.updated_at}</p>
+                    </div>
                 </Link>
             ))}
+            <button onClick={() => setPage(prevPage => prevPage + 1)}>
+                Load more posts
+            </button>
         </div>
     );
 };

--- a/frontend/src/shared/services/apiService.ts
+++ b/frontend/src/shared/services/apiService.ts
@@ -47,7 +47,27 @@ const apiRequest = async <T = undefined>(url: string, method = 'GET', options?: 
     }
 };
 
-export const fetchPosts = (): Promise<Post[]> => apiRequest(`${API_BASE_URL}/posts`);
+type FetchPostsOptions = {
+    page?: number;
+    limit?: number;
+}
+
+export const fetchPosts = (options: FetchPostsOptions = {}): Promise<Post[]> => {
+    let url = `${API_BASE_URL}/posts`;
+
+    const params = new URLSearchParams();
+    if (options.page != null) {
+        params.append('page', String(options.page));
+    }
+    if (options.limit != null) {
+        params.append('limit', String(options.limit));
+    }
+    if (params.toString()) {
+        url += `?${params.toString()}`;
+    }
+
+    return apiRequest(url);
+};
 
 export const fetchPostById = (id: number): Promise<Post> => apiRequest(`${API_BASE_URL}/posts/${id}`);
 


### PR DESCRIPTION
## やったこと
- /postsにリクエストパラメータpage, limitを追加
  - pageはページ番号
  - limitは、1ページで取得するpostの数

繋ぎこみ検証はまだ

## スクリーンショット
Load more postsボタンの設定
<img width="823" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/58862935/b233830e-f995-4f39-8169-6a0c10a9e1c2">
リクエストパラメータが変わっている様子
<img width="407" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/58862935/873b4f60-8262-483f-9466-db3bc0b48440">
