### PR TITLE
create_post_usecaseへのテスト追加、テスト用DB作成、delete_post_usecaseのファイル分割

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /docker/mysql
+/docker/mysql-test
 node_modules/
 tmp/
 backend/myapp

--- a/backend/internal/usecases/create_post_usecase_test.go
+++ b/backend/internal/usecases/create_post_usecase_test.go
@@ -1,0 +1,49 @@
+package usecases
+
+import (
+	"testing"
+
+	"fmt"
+	"myapp/internal/config"
+	"myapp/internal/repositories"
+	"os"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// Database Setup
+// !!! You have to call this function after config setup
+func SetupDB() *gorm.DB {
+	host := "db-test"
+	port := config.DBPort
+	dbname := config.DBName
+	dbUsername := config.DBUsername
+	dbPassword := config.DBPassword
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local", dbUsername, dbPassword, host, port, dbname)
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	return db
+}
+
+func TestExecute(t *testing.T) {
+	userId := 1
+	title := "test_title"
+	body := "test_body"
+
+	db := SetupDB()
+
+	r := repositories.NewPostRepository(db)
+	usecase := NewCreatePostUsecase(r)
+	result, err := usecase.Execute(userId, title, body)
+	if err != nil {
+		t.Fail()
+	}
+
+	if result.UserId != userId || result.Title != title || result.Body != body {
+		t.Fail()
+	}
+}

--- a/backend/internal/usecases/delete_post_usecase.go
+++ b/backend/internal/usecases/delete_post_usecase.go
@@ -1,0 +1,33 @@
+package usecases
+
+import (
+	"errors"
+	"myapp/internal/entities"
+	"myapp/internal/repositories"
+)
+
+type DeletePostUsecase struct {
+	repository entities.PostRepository
+}
+
+func NewDeletePostUsecase(r *repositories.PostRepository) *DeletePostUsecase {
+	return &DeletePostUsecase{
+		repository: r,
+	}
+}
+
+func (u *DeletePostUsecase) Execute(user_id, post_id int) error {
+	// ポストidからポストを取得します
+	post, err := u.repository.GetPostById(post_id)
+	if err != nil {
+		return err
+	}
+	// ポストのuser_idとユーザidを比較します
+	// 一致しない場合はエラーを返します
+	if post.UserId != user_id {
+		return errors.New("user_id does not match")
+	}
+
+	// 一致する場合はポストを削除します
+	return u.repository.DeletePost(post_id)
+}

--- a/backend/internal/usecases/post_usecase.go
+++ b/backend/internal/usecases/post_usecase.go
@@ -1,7 +1,6 @@
 package usecases
 
 import (
-	"errors"
 	"myapp/internal/entities"
 	"myapp/internal/repositories"
 )
@@ -51,30 +50,4 @@ func (u *GetPostByIdUsecase) Execute(user_id int, include_comments bool) (*entit
 	}
 
 	return post, nil
-}
-
-type DeletePostUsecase struct {
-	repository entities.PostRepository
-}
-
-func NewDeletePostUsecase(r *repositories.PostRepository) *DeletePostUsecase {
-	return &DeletePostUsecase{
-		repository: r,
-	}
-}
-
-func (u *DeletePostUsecase) Execute(user_id, post_id int) error {
-	// ポストidからポストを取得します
-	post, err := u.repository.GetPostById(post_id)
-	if err != nil {
-		return err
-	}
-	// ポストのuser_idとユーザidを比較します
-	// 一致しない場合はエラーを返します
-	if post.UserId != user_id {
-		return errors.New("user_id does not match")
-	}
-
-	// 一致する場合はポストを削除します
-	return u.repository.DeletePost(post_id)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,16 @@ services:
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=training
+  db-test:
+    build:
+      context: ./docker
+      dockerfile: mysql.Dockerfile
+    volumes:
+      - ./docker/mysql-test:/var/lib/mysql
+      - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./mysql/sql:/sqlscripts
+    ports:
+      - '3307:3306'
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+      - MYSQL_DATABASE=training


### PR DESCRIPTION
close #53 

## テストの実行方法
`docker compose exec backend go test ./...`

## Initial setup
db-testの初回起動時にはテーブルが存在しないためWebサーバへのアクセスがエラーになる。 起動後に以下のスクリプトを実行してテーブルの作成と初期データの投入を行う必要がある。
```
host$ docker-compose exec db-test sh -c "mysql < /sqlscripts/create.sql"
host$ docker-compose exec db-test sh -c "mysql training < /sqlscripts/insert.sql"
```