### PR TITLE
ポストリストのフィルタリング機能を追加し、公式と山田のファンミーティングページを作成

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {Route, Routes} from 'react-router-dom';
-import PostList from '../features/home/PostList';
+import PostList from '../features/posView/PostList';
+import OfficialMeeting from '../features/posView/OfficialMeeting';
+import YamadaMeeting from '../features/posView/YamadaMeeting';
 import NewPost from '../features/newPost/NewPost';
 import JoinClub from '../features/joinClub/JoinClub';
 import SignIn from '../features/signIn/SignIn';
@@ -18,6 +20,8 @@ const AppRouter: React.FC = () => {
             <Route path="/posts/:postId" element={<PostDetail />} />
             <Route path="/posts/:postId/edit" element={<EditPost/>}/>
             <Route path="/signup" element={<SignUp />} />
+            <Route path="/meeting/official" element={<OfficialMeeting />}/>
+            <Route path="/meeting/yamada" element={<YamadaMeeting />}/>
         </Routes>
     );
 };

--- a/frontend/src/features/posView/OfficialMeeting.tsx
+++ b/frontend/src/features/posView/OfficialMeeting.tsx
@@ -1,0 +1,10 @@
+import PostList from './PostList';
+import React from "react";
+
+const OfficialMeeting: React.FC = () => {
+    return (
+        <PostList type="official" />
+    );
+};
+
+export default OfficialMeeting;

--- a/frontend/src/features/posView/PostList.tsx
+++ b/frontend/src/features/posView/PostList.tsx
@@ -4,20 +4,28 @@ import {Link} from 'react-router-dom';
 import {fetchPosts} from '../../shared/services/apiService';
 
 
-const PostList: React.FC = () => {
+type FetchPostsOptions = {
+    page?: number;
+    limit?: number;
+    type?: 'official' | 'yamada';
+}
+
+
+type PostListProps = Partial<FetchPostsOptions>;
+
+const PostList: React.FC<PostListProps> = ({ type }) => {
     const [posts, setPosts] = useState<Post[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
-    const POSTS_PER_PAGE = 7; // 1ページでみやすい上限の数が7くらい
+    const POSTS_PER_PAGE = 7;
     const [page, setPage] = useState<number>(1);
-
 
     useEffect(() => {
         const getPosts = async () => {
             try {
                 setLoading(true);
-                const data = await fetchPosts({ page, limit: POSTS_PER_PAGE });
+                const data = await fetchPosts({ type, page, limit: POSTS_PER_PAGE });
                 setPosts(data);
             } catch (err) {
                 setError('An unexpected error occurred');
@@ -27,7 +35,7 @@ const PostList: React.FC = () => {
         };
 
         getPosts();
-    }, [page]);
+    }, [type, page]);
 
     if (loading) {
         return <div className="flex justify-center items-center h-full"><span className="text-lg font-semibold">Loading...</span></div>;

--- a/frontend/src/features/posView/YamadaMeeting.tsx
+++ b/frontend/src/features/posView/YamadaMeeting.tsx
@@ -1,0 +1,10 @@
+import PostList from './PostList';
+import React from "react";
+
+const YamadaMeeting: React.FC = () => {
+    return (
+        <PostList type="yamada" />
+    );
+};
+
+export default YamadaMeeting;

--- a/frontend/src/shared/components/Navigation.tsx
+++ b/frontend/src/shared/components/Navigation.tsx
@@ -8,6 +8,16 @@ const Navigation = () => {
         <nav className="bg-gray-100 p-4 shadow-md">
             <ul className="space-y-4">
                 <li><Link to="/" className="text-blue-500 hover:text-blue-700">Home</Link></li>
+                <li><Link to="/meeting/official"
+                          className="text-yellow-600 hover:text-yellow-900 flex">
+                    (公式)ファンミ
+                    <img src="/nagatani.png" className="h-6 mr-2" alt="Logo"/>
+                </Link></li>
+                <li><Link to="/meeting/yamada"
+                          className="text-gray-500 hover:text-gray-700 flex">
+                    (山田)ファンミ
+                    <img src="/yamada.png" className="h-6 mr-2" alt="Logo"/>
+                </Link></li>
                 {isLoggedIn ?
                     <li><Link to="/posts/new" className="text-blue-500 hover:text-blue-700">新規投稿</Link></li> : null}
                 <li>

--- a/frontend/src/shared/services/apiService.ts
+++ b/frontend/src/shared/services/apiService.ts
@@ -50,6 +50,7 @@ const apiRequest = async <T = undefined>(url: string, method = 'GET', options?: 
 type FetchPostsOptions = {
     page?: number;
     limit?: number;
+    type?: 'official' | 'yamada';
 }
 
 export const fetchPosts = (options: FetchPostsOptions = {}): Promise<Post[]> => {
@@ -61,6 +62,9 @@ export const fetchPosts = (options: FetchPostsOptions = {}): Promise<Post[]> => 
     }
     if (options.limit != null) {
         params.append('limit', String(options.limit));
+    }
+    if (options.type != null) {
+        params.append('type', options.type);
     }
     if (params.toString()) {
         url += `?${params.toString()}`;


### PR DESCRIPTION
<img width="381" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/58862935/d60d3f6e-0989-4f2e-a297-e09a9a3c2915">

こんな感じで、リクエストパラメータにtypeがついたりつかなかったり

- `PostList.tsx`のファイル名を`posView/PostList.tsx`に変更
- ポストのフィルタリング機能を作り、`FetchPostsOptions`にフィルターのタイプを追加
- `PostListProps`に`FetchPostsOptions`を追加し, 対策のためuseEffectの依存配列にもtypeを追加
- 公式と山田のナビゲーションリンクを作成し、対応するルートとコンポーネントを作成
- 新たに`OfficialMeeting.tsx`と`YamadaMeeting.tsx`というファイルを作成し、それぞれで`PostList`を適切なtypeでレンダーする

## スクリーンショット
<img width="286" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/58862935/83d65182-8ca7-4cbf-98ab-2e63a492bc3f">
