### PR TITLE
[meeting.a]Postテーブルの拡張

### DIFF
--- a/mysql/sql/alter_add_type_and_tag.sql
+++ b/mysql/sql/alter_add_type_and_tag.sql
@@ -1,0 +1,4 @@
+USE training;
+
+ALTER TABLE posts ADD type varchar(20) DEFAULT NULL;
+ALTER TABLE posts ADD tag varchar(20) DEFAULT NULL;

--- a/mysql/sql/create.sql
+++ b/mysql/sql/create.sql
@@ -20,6 +20,8 @@ CREATE TABLE IF NOT EXISTS posts(
   user_id    INT          NOT NULL,
   title      VARCHAR(100) NOT NULL,
   body       TEXT         NOT NULL,
+  type       VARCHAR(20),
+  tag        VARCHAR(20),
   created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   deleted_at DATETIME     NULL,


### PR DESCRIPTION
postsテーブルにtagカラムと typeカラムを追加

## initial setup
DBを初期化してもよい場合
- `docker compose down`
- `docker/mysql`を削除
- `docker compose up`
- `docker-compose exec db sh -c "mysql < /sqlscripts/create.sql"`
- `docker-compose exec db sh -c "mysql training < /sqlscripts/insert.sql"`

既存のDBに一意制約を付与する場合
- `docker-compose exec db sh -c "mysql < /sqlscripts/alter_add_type_and_tag.sql";`