### PR TITLE
[meeting.a]Post機能の拡張

### DIFF
--- a/backend/internal/controllers/post_controller.go
+++ b/backend/internal/controllers/post_controller.go
@@ -13,9 +13,14 @@ import (
 func GetPosts(ctx *gin.Context, usecase *usecases.ListPostUsecase) {
 	page, _ := strconv.Atoi(ctx.DefaultQuery("page", "1"))
 	limit, _ := strconv.Atoi(ctx.DefaultQuery("limit", "50"))
-	result, err := usecase.Execute(page, limit)
+	postType := ctx.DefaultQuery("type", "")
+	result, err := usecase.Execute(page, limit, postType)
 	if err != nil {
-		handleError(ctx, http.StatusInternalServerError, err)
+		if errors.Is(err, usecases.ErrInvalidPostType) {
+			handleError(ctx, http.StatusBadRequest, err)
+		} else {
+			handleError(ctx, http.StatusInternalServerError, err)
+		}
 	} else if result == nil {
 		ctx.JSON(http.StatusOK, []string{})
 	} else {
@@ -84,6 +89,7 @@ func DeletePost(ctx *gin.Context, usecase *usecases.DeletePostUsecase) {
 type PostRequest struct {
 	Title   string `json:"title"`
 	Content string `json:"content"`
+	Type    string `json:"meetingType"`
 }
 
 var ErrUserInfoNotFound = fmt.Errorf("user info not found")
@@ -102,7 +108,8 @@ func PostPost(ctx *gin.Context, usecase *usecases.CreatePostUsecase) {
 	}
 	userInfo := userInfoAny.(map[string]any)
 	userId := userInfo["Id"].(int)
-	result, err := usecase.Execute(userId, post.Title, post.Content)
+	fmt.Println("post.Type: ", post.Type)
+	result, err := usecase.Execute(userId, post.Title, post.Content, post.Type)
 	if err != nil {
 		handleError(ctx, http.StatusBadRequest, err)
 		return

--- a/backend/internal/entities/post.go
+++ b/backend/internal/entities/post.go
@@ -1,10 +1,10 @@
 package entities
 
 type PostRepository interface {
-	List(page int, limit int) ([]*Post, error)
+	List(page int, limit int, postType string) ([]*Post, error)
 	GetPostById(id int) (*Post, error)
 	DeletePost(id int) error
-	Create(userId int, title, body string) (*PostForInsert, error)
+	Create(userId int, title, body, postType string) (*PostForInsert, error)
 	Update(id int, title, body string) (*Post, error)
 }
 
@@ -12,6 +12,7 @@ type Post struct {
 	Id        int        `json:"id"`
 	Title     string     `json:"title"`
 	Body      string     `json:"body"`
+	Type      string     `json:"type"`
 	UserId    int        `json:"user_id"`
 	Username  string     `json:"username"`
 	Comments  []*Comment `json:"comments,omitempty"`
@@ -24,6 +25,7 @@ type PostForInsert struct {
 	UserId int    `json:"user_id"`
 	Title  string `json:"title"`
 	Body   string `json:"body"`
+	Type   string `json:"type"`
 }
 
 func NewPost(id int, title, body string, userId int, username, createdAt, updatedAt string) *Post {

--- a/backend/internal/usecases/create_post_usecase.go
+++ b/backend/internal/usecases/create_post_usecase.go
@@ -14,6 +14,9 @@ func NewCreatePostUsecase(r entities.PostRepository) *CreatePostUsecase {
 	}
 }
 
-func (u *CreatePostUsecase) Execute(userId int, title, body string) (*entities.PostForInsert, error) {
-	return u.repository.Create(userId, title, body)
+func (u *CreatePostUsecase) Execute(userId int, title, body, postType string) (*entities.PostForInsert, error) {
+	if postType != "" && postType != "Official" && postType != "Yamada" {
+		return nil, ErrInvalidPostType
+	}
+	return u.repository.Create(userId, title, body, postType)
 }

--- a/backend/internal/usecases/get_post_by_id_usecase.go
+++ b/backend/internal/usecases/get_post_by_id_usecase.go
@@ -4,28 +4,6 @@ import (
 	"myapp/internal/entities"
 )
 
-type ListPostUsecase struct {
-	repository entities.PostRepository
-}
-
-func NewListPostUsecase(r entities.PostRepository) *ListPostUsecase {
-	return &ListPostUsecase{
-		repository: r,
-	}
-}
-
-func (u *ListPostUsecase) Execute(page int, limit int) ([]*entities.Post, error) {
-	if page <= 0 {
-		page = 1
-	}
-
-	if limit <= 0 {
-		limit = 50
-	}
-
-	return u.repository.List(page, limit)
-}
-
 type GetPostByIdUsecase struct {
 	postRepository    entities.PostRepository
 	commentRepository entities.CommentRepository

--- a/backend/internal/usecases/get_posts_usecase.go
+++ b/backend/internal/usecases/get_posts_usecase.go
@@ -1,0 +1,34 @@
+package usecases
+
+import (
+	"fmt"
+	"myapp/internal/entities"
+	"myapp/internal/repositories"
+)
+
+type ListPostUsecase struct {
+	repository entities.PostRepository
+}
+
+func NewListPostUsecase(r *repositories.PostRepository) *ListPostUsecase {
+	return &ListPostUsecase{
+		repository: r,
+	}
+}
+
+var ErrInvalidPostType = fmt.Errorf("invalid post type")
+
+func (u *ListPostUsecase) Execute(page int, limit int, postType string) ([]*entities.Post, error) {
+	if page <= 0 {
+		page = 1
+	}
+
+	if limit <= 0 {
+		limit = 50
+	}
+	if postType != "" && postType != "Official" && postType != "Yamada" {
+		return nil, ErrInvalidPostType
+	}
+
+	return u.repository.List(page, limit, postType)
+}


### PR DESCRIPTION
close #69 

新規投稿時に、タグをファンミ告知にし、いずれかのファンミタイプを選択すると、そのファンミタイプがPostテーブル上に保存されるようにした

ファンミタイプ: 公式の選択例
![Screenshot 2024-06-28 at 11 10 22](https://github.com/givery-bootcamp/dena-2024-team9/assets/53257509/aa62a5f6-2253-46b3-9097-3b1ba6623d90)
