### PR TITLE
*entity.Userを返しているところから、passwordを無くす

### DIFF
--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -36,6 +36,7 @@ func PostSignin(ctx *gin.Context, usecase *usecases.PostSigninUsecase) {
 		}
 		return
 	}
+	user.Password = ""
 
 	ctx.SetSameSite(http.SameSiteStrictMode)
 	// ヘッダーにトークンをセット
@@ -87,6 +88,7 @@ func GetUser(ctx *gin.Context, usecase *usecases.GetUserUsecase) {
 		}
 		return
 	}
+	user.Password = ""
 
 	ctx.JSON(http.StatusOK, user)
 }
@@ -111,6 +113,7 @@ func PostSignup(ctx *gin.Context, usecase *usecases.PostSignupUsecase) {
 		handleError(ctx, http.StatusBadRequest, err)
 		return
 	}
+	user.Password = ""
 
 	ctx.JSON(http.StatusOK, user)
 


### PR DESCRIPTION
close #89 
画像のように元々パスワードも含めて返却していたが、セキュリティリスクがある
コントローラでの処理を変えて、passwordを返却しないように変更した

変更前
<img width="638" alt="スクリーンショット 2024-06-28 15 23 18" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/61158776/069e8319-e9d7-4c49-90c7-891eb5ed8454">

変更後
<img width="577" alt="スクリーンショット 2024-06-28 15 22 50" src="https://github.com/givery-bootcamp/dena-2024-team9/assets/61158776/ab1fcd0b-398b-4f72-b656-7a9a32b9ddfd">
